### PR TITLE
Rewrote some constraint logic to be more "auto layout" friendly.

### DIFF
--- a/CarbonKit/CarbonTabSwipeNavigation.m
+++ b/CarbonKit/CarbonTabSwipeNavigation.m
@@ -76,11 +76,9 @@
 	pageController.dataSource = self;
 	
 	// delegate scrollview
-	UIScrollView *delegateScrollView;
 	for (UIView *v in pageController.view.subviews) {
 		if ([v isKindOfClass:[UIScrollView class]]) {
-			delegateScrollView = (UIScrollView *)v;
-			delegateScrollView.delegate = self;
+			((UIScrollView *)v).delegate = self;
 		}
 	}
 	
@@ -175,24 +173,24 @@
 	[tabScrollView setShowsVerticalScrollIndicator:NO];
 	[tabScrollView setTranslatesAutoresizingMaskIntoConstraints:NO];
 	
+	[pageController.view setTranslatesAutoresizingMaskIntoConstraints: NO];
 	[self.view setTranslatesAutoresizingMaskIntoConstraints:NO];
-	[delegateScrollView setTranslatesAutoresizingMaskIntoConstraints:NO];
 	
 	// create constraints
-	UIView *viewControllerContainerView = self.view;
+	UIView *parentView = self.view;
+	UIView *pageControllerView = pageController.view;
 	id<UILayoutSupport> topLayoutGuide = self.topLayoutGuide;
-	NSDictionary *viewsDictionary = NSDictionaryOfVariableBindings(topLayoutGuide, tabScrollView, delegateScrollView, viewControllerContainerView);
+	NSDictionary *viewsDictionary = NSDictionaryOfVariableBindings(topLayoutGuide, tabScrollView, pageControllerView, parentView);
 	NSDictionary *metricsDictionary = @{
 										@"tabScrollViewHeight" : @44
 										};
 	
-	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[topLayoutGuide][tabScrollView(==tabScrollViewHeight)][delegateScrollView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
+	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[topLayoutGuide][tabScrollView(==tabScrollViewHeight)][pageControllerView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
 	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[tabScrollView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
-	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[delegateScrollView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
+	[rootViewController.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[pageControllerView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
 
-	[rootViewController.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[viewControllerContainerView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
-	[rootViewController.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[viewControllerContainerView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
-
+	[rootViewController.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[parentView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
+	[rootViewController.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[parentView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
 	
 	[indicator setTranslatesAutoresizingMaskIntoConstraints:NO];
 	[segmentController addConstraint:[NSLayoutConstraint constraintWithItem:indicator
@@ -335,6 +333,9 @@
 	indicatorWidthConst.constant = tab.frame.size.width;
 	indicatorLeftConst.constant = tab.frame.origin.x;
 	
+	// keep the page controller's width in sync
+	pageController.view.frame = CGRectMake(pageController.view.frame.origin.x, pageController.view.frame.origin.y, self.view.bounds.size.width, pageController.view.frame.size.height);
+
 	[self resizeTabs];
 	[self fixOffset];
 	[self.view layoutIfNeeded];

--- a/CarbonKit/CarbonTabSwipeNavigation.m
+++ b/CarbonKit/CarbonTabSwipeNavigation.m
@@ -179,17 +179,18 @@
 	// create constraints
 	UIView *parentView = self.view;
 	UIView *pageControllerView = pageController.view;
-	id<UILayoutSupport> topLayoutGuide = self.topLayoutGuide;
-	NSDictionary *viewsDictionary = NSDictionaryOfVariableBindings(topLayoutGuide, tabScrollView, pageControllerView, parentView);
+	id<UILayoutSupport> rootTopLayoutGuide = rootViewController.topLayoutGuide;
+    id<UILayoutSupport> rootBottomLayoutGuide = rootViewController.bottomLayoutGuide;
+	NSDictionary *viewsDictionary = NSDictionaryOfVariableBindings(rootTopLayoutGuide, rootBottomLayoutGuide, parentView, tabScrollView, pageControllerView);
 	NSDictionary *metricsDictionary = @{
 										@"tabScrollViewHeight" : @44
 										};
 	
-	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[topLayoutGuide][tabScrollView(==tabScrollViewHeight)][pageControllerView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
+	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[tabScrollView(==tabScrollViewHeight)][pageControllerView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
 	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[tabScrollView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
-	[rootViewController.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[pageControllerView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
+	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[pageControllerView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
 
-	[rootViewController.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[parentView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
+	[rootViewController.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[rootTopLayoutGuide][parentView][rootBottomLayoutGuide]" options:0 metrics:metricsDictionary views:viewsDictionary]];
 	[rootViewController.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[parentView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
 	
 	[indicator setTranslatesAutoresizingMaskIntoConstraints:NO];

--- a/CarbonKit/CarbonTabSwipeNavigation.m
+++ b/CarbonKit/CarbonTabSwipeNavigation.m
@@ -43,7 +43,6 @@
 	UISegmentedControl *segmentController;
 	UIImageView *indicator;
 	
-	NSLayoutConstraint *tabTopConstraint;
 	NSLayoutConstraint *indicatorLeftConst;
 	NSLayoutConstraint *indicatorWidthConst;
 }
@@ -85,25 +84,12 @@
 	
 	// add page controller as child
 	[self addChildViewController:pageController];
-	
-	// set page controller frame
-	CGRect pageRect = viewController.view.frame;
-	pageRect.origin.y = 44;
-	pageRect.size.height -= 44;
-	pageController.view.frame = pageRect;
 	[self.view addSubview:pageController.view];
-	
-	// finish adding page controller as child
 	[pageController didMoveToParentViewController:self];
 	
 	// add self as child to parent
 	[rootViewController addChildViewController:self];
-	
-	// set self.view frame
-	self.view.frame = rootViewController.view.frame;
 	[rootViewController.view addSubview:self.view];
-	
-	// finish adding self as a child to parent
 	[self didMoveToParentViewController:rootViewController];
 	
 	// create segment control
@@ -170,7 +156,7 @@
 	segmentController.frame = segmentRect;
 	
 	// create scrollview
-	tabScrollView = [[UIScrollView alloc] initWithFrame:CGRectMake(0, 64, self.view.frame.size.width, 44)];
+	tabScrollView = [[UIScrollView alloc] init];
 	[self.view addSubview:tabScrollView];
 	
 	// create indicator
@@ -187,54 +173,26 @@
 	[tabScrollView setShowsVerticalScrollIndicator:NO];
 	[tabScrollView setTranslatesAutoresizingMaskIntoConstraints:NO];
 	
-	if (viewController.navigationController) {
-		[self.view addConstraint:[NSLayoutConstraint constraintWithItem:tabScrollView
-								      attribute:NSLayoutAttributeTop
-								      relatedBy:NSLayoutRelationEqual
-									 toItem:self.view
-								      attribute:NSLayoutAttributeTop
-								     multiplier:1.0
-								       constant:0]];
-	} else {
-		CGFloat statusBarHeight = [UIApplication sharedApplication].statusBarFrame.size.height;
-		tabTopConstraint = [NSLayoutConstraint constraintWithItem:tabScrollView
-								attribute:NSLayoutAttributeTop
-								relatedBy:NSLayoutRelationEqual
-								   toItem:self.view
-								attribute:NSLayoutAttributeTop
-							       multiplier:1.0
-								 constant:statusBarHeight];
-		[self.view addConstraint:tabTopConstraint];
-	}
+	[self.view setTranslatesAutoresizingMaskIntoConstraints:NO];
+	[pageController.view setTranslatesAutoresizingMaskIntoConstraints:NO];
+
 	
-	[self.view addConstraint:[NSLayoutConstraint constraintWithItem:tabScrollView
-							      attribute:NSLayoutAttributeLeading
-							      relatedBy:NSLayoutRelationEqual
-								 toItem:self.view
-							      attribute:NSLayoutAttributeLeading
-							     multiplier:1.0
-							       constant:0]];
-	[self.view addConstraint:[NSLayoutConstraint constraintWithItem:tabScrollView
-							      attribute:NSLayoutAttributeTrailing
-							      relatedBy:NSLayoutRelationEqual
-								 toItem:self.view
-							      attribute:NSLayoutAttributeTrailing
-							     multiplier:1.0
-							       constant:0]];
-	[self.view addConstraint:[NSLayoutConstraint constraintWithItem:tabScrollView
-							      attribute:NSLayoutAttributeHeight
-							      relatedBy:NSLayoutRelationEqual
-								 toItem:self.view
-							      attribute:NSLayoutAttributeHeight
-							     multiplier:0
-							       constant:44]];
-	[self.view addConstraint:[NSLayoutConstraint constraintWithItem:tabScrollView
-							      attribute:NSLayoutAttributeWidth
-							      relatedBy:NSLayoutRelationEqual
-								 toItem:self.view
-							      attribute:NSLayoutAttributeWidth
-							     multiplier:1.0
-							       constant:0]];
+	// create constraints
+	UIView *viewControllerContainerView = self.view;
+	UIView *pageControllerView = pageController.view;
+	id<UILayoutSupport> topLayoutGuide = self.topLayoutGuide;
+	NSDictionary *viewsDictionary = NSDictionaryOfVariableBindings(topLayoutGuide, tabScrollView, pageControllerView, viewControllerContainerView);
+	NSDictionary *metricsDictionary = @{
+										@"tabScrollViewHeight" : @44
+										};
+	
+	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[topLayoutGuide][tabScrollView(==tabScrollViewHeight)][pageControllerView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
+	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[tabScrollView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
+	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[pageControllerView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
+
+	[rootViewController.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[viewControllerContainerView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
+	[rootViewController.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[viewControllerContainerView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
+
 	
 	[indicator setTranslatesAutoresizingMaskIntoConstraints:NO];
 	[segmentController addConstraint:[NSLayoutConstraint constraintWithItem:indicator
@@ -372,8 +330,6 @@
 
 - (void)viewDidLayoutSubviews {
 	[super viewDidLayoutSubviews];
-	CGFloat statusBarHeight = [UIApplication sharedApplication].statusBarFrame.size.height;
-	[tabTopConstraint setConstant:statusBarHeight];
 	
 	UIView *tab = tabs[segmentController.selectedSegmentIndex];
 	indicatorWidthConst.constant = tab.frame.size.width;

--- a/CarbonKit/CarbonTabSwipeNavigation.m
+++ b/CarbonKit/CarbonTabSwipeNavigation.m
@@ -76,9 +76,11 @@
 	pageController.dataSource = self;
 	
 	// delegate scrollview
+	UIScrollView *delegateScrollView;
 	for (UIView *v in pageController.view.subviews) {
 		if ([v isKindOfClass:[UIScrollView class]]) {
-			((UIScrollView *)v).delegate = self;
+			delegateScrollView = (UIScrollView *)v;
+			delegateScrollView.delegate = self;
 		}
 	}
 	
@@ -174,21 +176,19 @@
 	[tabScrollView setTranslatesAutoresizingMaskIntoConstraints:NO];
 	
 	[self.view setTranslatesAutoresizingMaskIntoConstraints:NO];
-	[pageController.view setTranslatesAutoresizingMaskIntoConstraints:NO];
-
+	[delegateScrollView setTranslatesAutoresizingMaskIntoConstraints:NO];
 	
 	// create constraints
 	UIView *viewControllerContainerView = self.view;
-	UIView *pageControllerView = pageController.view;
 	id<UILayoutSupport> topLayoutGuide = self.topLayoutGuide;
-	NSDictionary *viewsDictionary = NSDictionaryOfVariableBindings(topLayoutGuide, tabScrollView, pageControllerView, viewControllerContainerView);
+	NSDictionary *viewsDictionary = NSDictionaryOfVariableBindings(topLayoutGuide, tabScrollView, delegateScrollView, viewControllerContainerView);
 	NSDictionary *metricsDictionary = @{
 										@"tabScrollViewHeight" : @44
 										};
 	
-	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[topLayoutGuide][tabScrollView(==tabScrollViewHeight)][pageControllerView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
+	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[topLayoutGuide][tabScrollView(==tabScrollViewHeight)][delegateScrollView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
 	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[tabScrollView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
-	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[pageControllerView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
+	[self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[delegateScrollView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
 
 	[rootViewController.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[viewControllerContainerView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];
 	[rootViewController.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[viewControllerContainerView]|" options:0 metrics:metricsDictionary views:viewsDictionary]];


### PR DESCRIPTION
This is an optimization in the CarbonKitTabNavigation class. We have removed some initial frame setting of views. Also, new constraint logic honors the top layout guide, which allows us to completely remove the tabTopConstraint variable, as well as all status bar frame logic.