### PR TITLE
Allow subclasses to override tab view height

### DIFF
--- a/CarbonKit/CarbonTabSwipeNavigation.m
+++ b/CarbonKit/CarbonTabSwipeNavigation.m
@@ -630,7 +630,7 @@
 	CGFloat indicatorMaxOriginX = scrollView.frame.size.width / 2 - indicator.frame.size.width / 2;
 	
 	CGFloat offsetX = indicator.frame.origin.x-indicatorMaxOriginX;
-	t
+	
 	if (offsetX < 0) offsetX = 0;
 	if (offsetX > segmentController.frame.size.width-scrollViewWidth) offsetX = segmentController.frame.size.width-scrollViewWidth;
 	


### PR DESCRIPTION
Added overridable method -(NSNumber*)tabHeight, to allow subclasses to specify a tab height. This is particularly useful if you'd like to hide the tabs on a particular view, while still allowing the swiping motion.