### PR TITLE
Allow subclasses to enable/disable animation

### DIFF
--- a/CarbonKit/CarbonTabSwipeNavigation.m
+++ b/CarbonKit/CarbonTabSwipeNavigation.m
@@ -337,7 +337,7 @@
 	pageController.view.userInteractionEnabled = NO;
 	[pageController setViewControllers:@[viewController]
 				 direction:animateDirection
-				  animated:NO
+				  animated:[self shouldAnimate]
 				completion:^(BOOL finished) {
 					__strong __typeof__(self) strongSelf = weakSelf;
 					strongSelf->isNotDragging = NO;
@@ -367,7 +367,7 @@
 	__weak __typeof__(self) weakSelf = self;
 	[pageController setViewControllers:@[viewController]
 							 direction:UIPageViewControllerNavigationDirectionForward
-							  animated:NO
+							  animated:[self shouldAnimate]
 							completion:^(BOOL finished) {
 								__strong __typeof__(self) strongSelf = weakSelf;
 								// call delegate
@@ -641,11 +641,16 @@
 	previewsOffset = scrollView.contentOffset;
 }
 
-#pragma mark - Subclassing
+#pragma mark - Subclass and override to customize
 
 -(NSNumber*)tabHeight
 {
-    return @44;
+    return @50;
+}
+
+-(BOOL)shouldAnimate
+{
+    return YES;
 }
 
 @end

--- a/CarbonKit/CarbonTabSwipeNavigation.m
+++ b/CarbonKit/CarbonTabSwipeNavigation.m
@@ -645,7 +645,7 @@
 
 -(NSNumber*)tabHeight
 {
-    return @50;
+    return @44;
 }
 
 -(BOOL)shouldAnimate


### PR DESCRIPTION
Subclasses may override -(BOOL)shouldAnimate to control view controller slide animation, on tab bar tap as well as manual setIndex calls.