### PR TITLE
add help to embed carbontab as childcontroller

### DIFF
--- a/CarbonKit/CarbonTabSwipeNavigation.h
+++ b/CarbonKit/CarbonTabSwipeNavigation.h
@@ -205,15 +205,6 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param extraWidth Extra width value
  */
 - (void)setTabExtraWidth:(CGFloat)extraWidth;
-
-
-/**
- *  If embedded in another viewcontroller which will disappear.
- *  This function helps getting this information down to the pageViewController
- *	so viewWillDisappear and viewDidDisappear will be called in children
- */
-- (void)prepareForDisappearance;
-
 NS_ASSUME_NONNULL_END
 
 @end

--- a/CarbonKit/CarbonTabSwipeNavigation.h
+++ b/CarbonKit/CarbonTabSwipeNavigation.h
@@ -206,6 +206,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)setTabExtraWidth:(CGFloat)extraWidth;
 
+
+/**
+ *  If embedded in another viewcontroller which will disappear.
+ *  This function helps getting this information down to the pageViewController
+ *	so viewWillDisappear and viewDidDisappear will be called in children
+ */
+- (void)prepareForDisappearance;
+
 NS_ASSUME_NONNULL_END
 
 @end

--- a/CarbonKit/CarbonTabSwipeNavigation.m
+++ b/CarbonKit/CarbonTabSwipeNavigation.m
@@ -123,6 +123,10 @@ UIPageViewControllerDataSource, UIScrollViewDelegate, UIToolbarDelegate>
 	[super viewDidAppear:animated];
 	[self syncIndicator];
 }
+- (void)dealloc
+{
+	[self prepareForDisappearance];
+}
 
 - (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation
 								duration:(NSTimeInterval)duration {

--- a/CarbonKit/CarbonTabSwipeNavigation.m
+++ b/CarbonKit/CarbonTabSwipeNavigation.m
@@ -719,5 +719,11 @@ UIPageViewControllerDataSource, UIScrollViewDelegate, UIToolbarDelegate>
 - (void)setTabExtraWidth:(CGFloat)extraWidth {
 	self.carbonSegmentedControl.tabExtraWidth = extraWidth;
 }
-
+-(void)prepareForDisappearance{
+	[_pageViewController willMoveToParentViewController:nil];
+	[_pageViewController beginAppearanceTransition:NO animated:YES];    
+	[_pageViewController.view removeFromSuperview]; 
+	[_pageViewController removeFromParentViewController];
+	[_pageViewController endAppearanceTransition];
+}
 @end


### PR DESCRIPTION
When you embed CarbonTabNavigationController within a viewcontroller and that viewcontroller will disappear the events won't get through to the tab-viewcontroller. 
I fixed this issue by calling the new function in the viewWillDisappear of the parent viewcontroller:

```
- (void)willMoveToParentViewController:(UIViewController *)parent{
    if (parent == NULL) {
        [carbonTabSwipeNavigation prepareForDisappearance];
    }
}
```

Let me know if I can help make it more elegant. 