### PR TITLE
Fixing a link to toolbarHeight layout constraint.

### DIFF
--- a/CarbonKit/CarbonTabSwipeNavigation.h
+++ b/CarbonKit/CarbonTabSwipeNavigation.h
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface CarbonTabSwipeNavigation : UIViewController
 
 @property(nonatomic) NSUInteger currentTabIndex;
-@property(nonatomic) NSLayoutConstraint *toolbarHeight;
+@property(nonatomic, readonly) NSLayoutConstraint *toolbarHeight;
 @property(nonatomic, nonnull) UIToolbar *toolbar;
 @property(nonatomic, nonnull) UIPageViewController *pageViewController;
 @property(nonatomic, nonnull) CarbonTabSwipeScrollView *carbonTabSwipeScrollView;

--- a/CarbonKit/CarbonTabSwipeNavigation.m
+++ b/CarbonKit/CarbonTabSwipeNavigation.m
@@ -529,16 +529,6 @@
                                                                       options:0
                                                                       metrics:nil
                                                                         views:views]];
-
-    self.toolbarHeight = [NSLayoutConstraint constraintWithItem:self.toolbar
-                                                      attribute:NSLayoutAttributeHeight
-                                                      relatedBy:NSLayoutRelationEqual
-                                                         toItem:nil
-                                                      attribute:NSLayoutAttributeNotAnAttribute
-                                                     multiplier:1.0
-                                                       constant:40];
-
-    [self.view addConstraint:self.toolbarHeight];
 }
 
 - (void)createTabSwipeScrollViewWithItems:(NSArray *)items {
@@ -636,6 +626,16 @@
         NSInteger index = self.carbonSegmentedControl.selectedSegmentIndex;
         [self.delegate carbonTabSwipeNavigation:self didMoveAtIndex:index];
     }
+}
+
+- (NSLayoutConstraint *)toolbarHeight {
+	for (NSLayoutConstraint *constraint in self.toolbar.constraints) {
+		if ([NSStringFromClass(constraint.class) isEqualToString:@"NSContentSizeLayoutConstraint"]) {
+			return constraint;
+		}
+	}
+	
+	return nil;
 }
 
 - (void)setTabBarHeight:(CGFloat)height {


### PR DESCRIPTION
#85 

`UIToolbar` generate `NSContentSizeLayoutConstraint` for height itself.
So, we don't have to make a constraint for height.

This PR makes that `toolbarHeight` link to right constraint.

But, this way has a weak point.
`UIToolbar` seems to make own height-layout-constraint so late.(after showing on screen a.k.a viewDidLoad)
So it can't be handled before generated.