### PR TITLE
Adding page transition delegate

### DIFF
--- a/CarbonKit/CarbonTabSwipeNavigation.h
+++ b/CarbonKit/CarbonTabSwipeNavigation.h
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param index Target index
  */
 - (void)carbonTabSwipeNavigation:(nonnull CarbonTabSwipeNavigation *)carbonTabSwipeNavigation
-                 willMoveAtIndex:(NSUInteger)index;
+				 willMoveAtIndex:(NSUInteger)index;
 
 /**
  *  Did move to index
@@ -61,7 +61,25 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param index Current index
  */
 - (void)carbonTabSwipeNavigation:(nonnull CarbonTabSwipeNavigation *)carbonTabSwipeNavigation
-                  didMoveAtIndex:(NSUInteger)index;
+				  didMoveAtIndex:(NSUInteger)index;
+
+/**
+ *  Will start the page transition from index.
+ *
+ *  @param carbonTabSwipeNavigation CarbonTabSwipeNavigation instance
+ *  @param index Starting index
+ */
+- (void)carbonTabSwipeNavigation:(nonnull CarbonTabSwipeNavigation *)carbonTabSwipeNavigation
+	willBeginTransitionFromIndex:(NSUInteger)index;
+
+/**
+ *  Did finish the page transition to index.
+ *
+ *  @param carbonTabSwipeNavigation CarbonTabSwipeNavigation instance
+ *  @param index Target index
+ */
+- (void)carbonTabSwipeNavigation:(nonnull CarbonTabSwipeNavigation *)carbonTabSwipeNavigation
+	  didFinishTransitionToIndex:(NSUInteger)index;
 
 /**
  *  Toolbar position

--- a/CarbonKit/CarbonTabSwipeNavigation.m
+++ b/CarbonKit/CarbonTabSwipeNavigation.m
@@ -255,10 +255,14 @@
 #pragma mark - PageViewController Delegate
 
 - (void)pageViewController:(UIPageViewController *)pageViewController
+willTransitionToViewControllers:(NSArray<UIViewController *> *)pendingViewControllers {
+	[self callDelegateForStartingTransition];
+}
+
+- (void)pageViewController:(UIPageViewController *)pageViewController
         didFinishAnimating:(BOOL)finished
    previousViewControllers:(NSArray *)previousViewControllers
-       transitionCompleted:(BOOL)completed {
-
+	   transitionCompleted:(BOOL)completed {
     if (completed) {
         id currentView = pageViewController.viewControllers.firstObject;
         selectedIndex =
@@ -268,7 +272,9 @@
         [self.carbonSegmentedControl updateIndicatorWithAnimation:NO];
 
         [self callDelegateForCurrentIndex];
-    }
+	}
+	
+	[self callDelegateForFinishingTransition];
 }
 
 #pragma mark - ScrollView Delegate
@@ -636,6 +642,20 @@
         NSInteger index = self.carbonSegmentedControl.selectedSegmentIndex;
         [self.delegate carbonTabSwipeNavigation:self didMoveAtIndex:index];
     }
+}
+
+- (void)callDelegateForStartingTransition {
+	if ([self.delegate respondsToSelector:@selector(carbonTabSwipeNavigation:willBeginTransitionFromIndex:)]) {
+		NSInteger index = self.carbonSegmentedControl.selectedSegmentIndex;
+		[self.delegate carbonTabSwipeNavigation:self willBeginTransitionFromIndex:index];
+	}
+}
+
+- (void)callDelegateForFinishingTransition {
+	if ([self.delegate respondsToSelector:@selector(carbonTabSwipeNavigation:didFinishTransitionToIndex:)]) {
+		NSInteger index = self.carbonSegmentedControl.selectedSegmentIndex;
+		[self.delegate carbonTabSwipeNavigation:self didFinishTransitionToIndex:index];
+	}
 }
 
 - (void)setTabBarHeight:(CGFloat)height {


### PR DESCRIPTION
I have some reason to know transition moments.

I firstly thought `UIPageViewDelegate` methods through `CarbonTabSwipeNavigationDelegate` would be good. But, I was afraid that will be messed up it's consistency.

So i suggest that adding delegates
```objc
- (void)carbonTabSwipeNavigation:(nonnull CarbonTabSwipeNavigation *)carbonTabSwipeNavigation
	willBeginTransitionFromIndex:(NSUInteger)index;

- (void)carbonTabSwipeNavigation:(nonnull CarbonTabSwipeNavigation *)carbonTabSwipeNavigation
	  didFinishTransitionToIndex:(NSUInteger)index;
```