### PR TITLE
fixes issue where tab bar scroll view alignment was off when changing…

### DIFF
--- a/CarbonKit/CarbonTabSwipeNavigation.m
+++ b/CarbonKit/CarbonTabSwipeNavigation.m
@@ -143,11 +143,13 @@
 
 - (void)didRotateFromInterfaceOrientation:(UIInterfaceOrientation)fromInterfaceOrientation {
     [self.pageViewController.view layoutSubviews];
+    [self.pagesScrollView setNeedsLayout];
     isSwipeLocked = NO;
 }
 
 - (void)viewWillLayoutSubviews {
     [super viewWillLayoutSubviews];
+    [self.pagesScrollView setNeedsLayout];
     [self.pageViewController.view setNeedsLayout];
 }
 


### PR DESCRIPTION
… device ortientations. Was happening for me when 5th tab was selected, there were tabs off screen, and I would rotate from portrait to landscape